### PR TITLE
[SpotifyCouve] fixed bug where category names are in sentence case

### DIFF
--- a/couveSpotify.css
+++ b/couveSpotify.css
@@ -173,10 +173,6 @@
   right: 0.5rem;
 }
 
-h3 > [class^="overflow"] {
-  text-transform: capitalize;
-}
-
 :root
   .guilds-2JjMmN.guilds-2JjMmN
   .scroller-3X7KbA


### PR DESCRIPTION
### the bug
the channel names showed in title case, and I had no other quickcss/theme enabled.
then I looked through the CSS and found that 
```
h3 > [class^="overflow"] {
  text-transform: capitalize;
}
```
which turned category titles in title case, so I removed it.
and it doesn't seem to affect the spotify controls.
<img src="https://i.imgur.com/szvKRj9.png">
### screenshots
before:
<img src="https://i.imgur.com/F4HyYXE.png">
after:
<img src="https://i.imgur.com/AmnDr2V.png">